### PR TITLE
Make the entire day period grid cell clickable

### DIFF
--- a/src/components/Month.tsx
+++ b/src/components/Month.tsx
@@ -15,7 +15,7 @@ interface PeriodProps {
   readonly onChange: (period: Period) => Promise<void>
 }
 
-const PeriodWrapper = styled('div')`
+const PeriodWrapper = styled('label')`
   display: grid;
   grid-template-rows: 4rem 1rem;
   grid-template-columns: 1rem 4rem 1fr;
@@ -163,7 +163,7 @@ function handleClick({
 }
 
 const DayPeriod = (props: PeriodProps) => (
-  <PeriodWrapper>
+  <PeriodWrapper for={props.id}>
     <Checkbox id={props.id} checked={props.checked} onClick={handleClick(props)} />
     <MonthDay for={props.id}>{format(props.starts, 'D')}</MonthDay>
     <WeekDay for={props.id}>{format(props.starts, 'ddd')}</WeekDay>


### PR DESCRIPTION
# Before
![increase-hit-area-before](https://user-images.githubusercontent.com/9969/50718994-e16d9880-108d-11e9-89a6-925ff96f8ee0.gif)
# After
![increase-hit-area-after](https://user-images.githubusercontent.com/9969/50718992-d6b30380-108d-11e9-9a44-0b9d2a478a77.gif)
